### PR TITLE
Add Bazel Steward

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -1,0 +1,15 @@
+name: Bazel Steward
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 5 * * *' # runs every day at 5:30 am
+
+jobs:
+  bazel-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: VirtusLab/bazel-steward@latest


### PR DESCRIPTION
Add Bazel Steward to automatically update Bazel dependencies.
This should start working after merge to main branch. In case there will be issues, I will remove it.